### PR TITLE
Add Visual Studio Code support

### DIFF
--- a/sensor/sensor01_fw/.vscode/arduino.json
+++ b/sensor/sensor01_fw/.vscode/arduino.json
@@ -1,0 +1,7 @@
+{
+    "programmer": "AVRISP mkII",
+    "board": "arduino:avr:pro",
+    "configuration": "cpu=8MHzatmega328",
+    "sketch": "sensor01_fw.ino",
+    "port": "/dev/ttyUSB1"
+}

--- a/sensor/sensor01_fw/.vscode/c_cpp_properties.json
+++ b/sensor/sensor01_fw/.vscode/c_cpp_properties.json
@@ -1,0 +1,33 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${env:HOME}/arduino-1.8.13/tools/**",
+                "${env:HOME}/arduino-1.8.13/hardware/tools/avr/avr/include/**",
+                "${env:HOME}/arduino-1.8.13/hardware/tools/avr/avr/include/avr/**",
+                "${env:HOME}/arduino-1.8.13/hardware/arduino/avr/**",
+                "${env:HOME}/arduino-1.8.13/hardware/arduino/avr/cores/arduino/**",
+                "${env:HOME}/arduino-1.8.13/hardware/tools/avr/avr/include/**",
+                "${env:HOME}/arduino-1.8.13/hardware/tools/avr/lib/gcc/avr/7.3.0/include/**",
+                "${env:HOME}/arduino-1.8.13/hardware/arduino/avr/variants/standard/**",
+                "${env:HOME}/arduino-1.8.13/hardware/arduino/avr/**",
+                "${env:HOME}/Arduino/libraries/**",
+                "${env:HOME}/Arduino/libraries/Low-Power/**",
+                "${env:HOME}/Arduino/libraries/SparkFun_SHTC3_Humidity_and_Temperature_Sensor_Library/src/**"
+            ],
+            "forcedInclude": [
+                "${env:HOME}/arduino-1.8.13/hardware/arduino/avr/cores/arduino/Arduino.h"
+            ],
+            "intelliSenseMode": "gcc-x64",
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "gnu11",
+            "cppStandard": "c++17",
+            "defines": [
+                "USBCON",
+                "__AVR__"
+            ]
+        }
+    ],
+    "version": 4
+}

--- a/sensor/sensor01_fw/.vscode/settings.json
+++ b/sensor/sensor01_fw/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+        "cSpell.words": [
+                "SHTC",
+                "Tcrc",
+                "Tmega",
+                "println"
+        ]
+}


### PR DESCRIPTION
Config files for VSC using arduino-1.8.13 IDE under
your home directory.

If you want to use a different Arduino IDE version
or location, adjust "$HOME/arduino-1.8.13/"
includePath in sensor/sensor01_fw/.vscode/c_cpp_properties.json

Signed-off-by: Dragan Stancevic <dragan@stancevic.com>